### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "url": "https://github.com/richmulhern/node-usps_apis.git"
   },
   "dependencies": {
-    "xml2js": "~0.2.0",
-  },
+    "xml2js": "~0.2.0"
+  }
 }


### PR DESCRIPTION
Npm@2.7.0 wont install this module due to those extra commas:

npm ERR! Linux 2.6.32-042stab094.8
npm ERR! argv "node" "/usr/bin/npm" "link"
npm ERR! node v0.10.33
npm ERR! npm  v2.7.0
npm ERR! file /home/ning/node-usps_apis/package.json
npm ERR! code EJSONPARSE

npm ERR! Failed to parse json
npm ERR! Unexpected token }
npm ERR! File: /home/ning/node-usps_apis/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! Please include the following file with any support request:
npm ERR!     /home/ning/node-usps_apis/npm-debug.log
